### PR TITLE
fix `_ps_arg_analysis()` by stripping newlines from each function name in the function list before parsing it

### DIFF
--- a/pacman-switch.sh
+++ b/pacman-switch.sh
@@ -876,8 +876,10 @@ _ps_arg_analysis() {
 				len++
 		if (len >= $2) {
 			split($3, funcs, ",")
-			for (i in funcs)
+			for (i in funcs) {
+				gsub(/\n/, "", funcs[i])
 				print "_ps_" funcs[i] "=true"
+			}
 			for (i in args_array)
 				if (args_array[i] == $1)
 					delete args_array[i]


### PR DESCRIPTION
- Fixes https://github.com/termux-pacman/pacman-switch/issues/2